### PR TITLE
Fix investors layout and expand signal list

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
       <section id="overview" class="active">
         <div class="hero">
           <h2>
-            When <span class="highlight">22 strategic indicators</span> signal disruption, 
+            When <span class="highlight">9 ultra-sensitive signals</span> signal disruption,
             your family needs more than news—you need <span class="highlight">actionable intelligence</span>.
           </h2>
           <p style="font-size: 1.25rem; margin-bottom: 2rem;">
@@ -339,7 +339,7 @@
           <div class="grid" style="margin-top: 2rem;">
             <div class="card">
               <h3 style="color: var(--teal);">Real-Time Intelligence</h3>
-              <p>Monitor 22 strategic indicators from export controls to capital gates, with automated alerts when patterns match historical pre-conflict signals.</p>
+              <p>Monitor 25 strategic indicators from export controls to capital gates, with automated alerts when patterns match historical pre-conflict signals.</p>
             </div>
             <div class="card">
               <h3 style="color: var(--teal);">Family Coordination</h3>
@@ -361,7 +361,7 @@
         <div class="grid">
           <div class="card">
             <h3>Automated Monitoring</h3>
-            <p>Our Watcher API continuously scans for 22 strategic indicators:</p>
+            <p>Our Watcher API continuously scans for 25 strategic indicators:</p>
             <ul style="font-size: 0.875rem;">
               <li>Industrial policy shifts (DPA waivers, export controls)</li>
               <li>Financial system stress (capital gates, FX restrictions)</li>
@@ -469,7 +469,7 @@
           </div>
         </div>
 
-        <div class="card" style="background: rgba(45, 212, 191, 0.1); text-align: center;">
+        <div class="card" style="background: rgba(45, 212, 191, 0.1); text-align: center; margin-top: 2rem;">
           <h3>Join Our Mission</h3>
           <p style="font-size: 1.125rem; margin: 1rem 0;">
             We're raising a $2M seed round to scale from beta to 10,000 paying families.
@@ -530,7 +530,7 @@
         <div class="grid">
           <div class="card">
             <h3>Watcher API</h3>
-            <p>Monitors 22 strategic indicators across global news feeds, government filings, and market data.</p>
+            <p>Monitors 25 strategic indicators across global news feeds, government filings, and market data.</p>
             <ul>
               <li>Defense Production Act waivers</li>
               <li>Export control changes (ASML, rare earths)</li>
@@ -882,7 +882,7 @@
           <ol style="font-family: monospace; font-size: 0.875rem;">
             <li>Fork the Civil-Net watcher repository</li>
             <li>Add to your GitHub Actions (runs free every 30 min)</li>
-            <li>Customize the 22 signals for your specific concerns</li>
+            <li>Customize the 25 signals for your specific concerns</li>
           </ol>
           <p style="margin-top: 1rem;">
             <a href="#" class="btn" style="background: transparent; border: 2px solid var(--teal); color: var(--teal);">
@@ -909,7 +909,7 @@
       <section id="manual">
         <div class="section-header">
           <h2>Early Warning Indicators</h2>
-          <p>22 strategic signals that historically precede major disruptions.</p>
+          <p>25 strategic signals that historically precede major disruptions.</p>
         </div>
 
         <h3 style="margin: 2rem 0 1rem;">Industrial & Military Signals</h3>
@@ -929,6 +929,26 @@
           <div class="card">
             <h4>4. TSMC Military Clauses</h4>
             <p>Fab construction delays over "military use" provisions reveal chip weaponization.</p>
+          </div>
+          <div class="card">
+            <h4>5. Domestic Steel Nationalization</h4>
+            <p>Priority claims on steel mills hint at long-term conflict planning.</p>
+          </div>
+          <div class="card">
+            <h4>6. Port Cybersecurity Drills</h4>
+            <p>Rapid deployment of port security teams suggests imminent logistics disruption.</p>
+          </div>
+          <div class="card">
+            <h4>7. Strategic Stockpile Releases</h4>
+            <p>Large reserve drawdowns signal expectation of supply shocks.</p>
+          </div>
+          <div class="card">
+            <h4>8. Fuel Ration Card Trials</h4>
+            <p>Short-term ration exercises precede transportation limits.</p>
+          </div>
+          <div class="card">
+            <h4>9. Mandatory Convoy Permits</h4>
+            <p>Government control over bulk transport indicates high-risk conditions.</p>
           </div>
         </div>
 
@@ -950,6 +970,26 @@
             <h4>13. Capital Outflow Gates</h4>
             <p>FX restrictions trap investor capital, signaling imminent devaluation.</p>
           </div>
+          <div class="card">
+            <h4>14. Savings Bond Mandates</h4>
+            <p>Forced investment into government bonds signals wartime financing pressure.</p>
+          </div>
+          <div class="card">
+            <h4>15. Bank Withdrawal Limits</h4>
+            <p>Strict daily cash caps often precede broader capital controls.</p>
+          </div>
+          <div class="card">
+            <h4>16. War Tax Surcharge</h4>
+            <p>Sweeping surcharges on transactions indicate fiscal mobilization.</p>
+          </div>
+          <div class="card">
+            <h4>17. Travel Permit Requirements</h4>
+            <p>Exit permits alongside currency controls warn of border lockdowns.</p>
+          </div>
+          <div class="card">
+            <h4>18. Central Bank Gold Calls</h4>
+            <p>Sudden requests for private gold deposits hint at currency backing shortages.</p>
+          </div>
         </div>
 
         <h3 style="margin: 2rem 0 1rem;">Social Control Signals</h3>
@@ -969,6 +1009,18 @@
           <div class="card">
             <h4>22. Pre-Approved Curfews</h4>
             <p>Legal framework precedes implementation by 6-12 months.</p>
+          </div>
+          <div class="card">
+            <h4>23. Nationwide ID Checks</h4>
+            <p>Random ID checkpoints reappear during heightened security status.</p>
+          </div>
+          <div class="card">
+            <h4>24. Internet Blackout Drills</h4>
+            <p>Planned outages or kill-switch tests indicate censorship preparation.</p>
+          </div>
+          <div class="card">
+            <h4>25. Citizen Mobilization Apps</h4>
+            <p>Mandatory alert apps signal expectation of mass coordination.</p>
           </div>
         </div>
 
@@ -1048,7 +1100,7 @@
             <tr>
               <td><strong>Family</strong></td>
               <td>$15/mo</td>
-              <td>• 10 users<br>• All 22 indicators<br>• Role matrix<br>• Unlimited inventory<br>• Encrypted vault</td>
+              <td>• 10 users<br>• All 25 indicators<br>• Role matrix<br>• Unlimited inventory<br>• Encrypted vault</td>
               <td>Nuclear family coordination</td>
             </tr>
             <tr>


### PR DESCRIPTION
## Summary
- tweak join mission card spacing on investors section
- count only 9 ultra‑sensitive signals on the landing hero
- update indicator references from 22 to 25 across the site
- list new strategic signals in the Field Manual

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68432fd67fe083219a872bcd7ab4bf00